### PR TITLE
Replace npm install by npm ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Resource Discovery Portal
 
 After cloning, go to the project folder and install node modules
-`npm install`
+
+    npm ci
 
 After installing run
-`npm run dev`
+
+    npm run dev
 
 This project is built with Vue 3 + Vite, ESLint, Prettier, TailwindCSS, Vue Router, Vuex


### PR DESCRIPTION
Replace `npm install` by `npm ci` to use the package versions defined in `package-lock.json`.